### PR TITLE
[IMPROVEMENT] optimize the requests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,19 +66,28 @@ const DictionaryApp = () => {
       if (definition) {
           setResult(definition.meanings);
 
-          // Fetch Chinese translations for all definitions
-          const newTranslations = {};
+          // Fetch Chinese translations for all definitions in parallel
+          const translationPromises = [];
+          const translationKeys = [];
+
           for (let meaningIndex = 0; meaningIndex < definition.meanings.length; meaningIndex++) {
               const meaning = definition.meanings[meaningIndex];
               for (let defIndex = 0; defIndex < meaning.definitions.length; defIndex++) {
                   const def = meaning.definitions[defIndex];
                   const key = `${meaningIndex}-${defIndex}`;
-                  const translation = await translateToChinese(def.definition);
-                  if (translation) {
-                      newTranslations[key] = translation;
-                  }
+                  translationKeys.push(key);
+                  translationPromises.push(translateToChinese(def.definition));
               }
           }
+
+          // Wait for all translations to complete
+          const translationResults = await Promise.all(translationPromises);
+          const newTranslations = {};
+          translationResults.forEach((translation, index) => {
+              if (translation) {
+                  newTranslations[translationKeys[index]] = translation;
+              }
+          });
           setTranslations(newTranslations);
       } else {
           setError("No definition found for the word.");


### PR DESCRIPTION
The optimization:
  - Before: Sequential requests - if a word had 5 definitions, it would take 5 × 2+ seconds = 10+
  seconds
  - After: Parallel requests using Promise.all - all 5 translations happen simultaneously, taking
  only ~2 seconds total

  Now all Chinese translations will load much faster since they're fetched concurrently rather than waiting for each one to complete before starting the next.